### PR TITLE
feat: add search-service route

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,12 @@ spring:
             - Path=/api/v1/moderation/**
           filters:
             - RewritePath=/api/v1/(?<segment>.*), /${segment}
+        - id: search-service
+          uri: ${SEARCH_SERVICE_URL:http://localhost:8084}
+          predicates:
+            - Path=/api/v1/search/**
+          filters:
+            - RewritePath=/api/v1/(?<segment>.*), /${segment}
   data:
     redis:
       host: ${REDIS_HOST:localhost}


### PR DESCRIPTION
## Summary
- Add route for search-service at `/api/v1/search/**`
- Routes to `${SEARCH_SERVICE_URL:http://localhost:8084}`

## Test plan
- [ ] Verify route configuration is correct
- [ ] Test search endpoint through gateway when search-service is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)