### PR TITLE
fix(ci): enable JaCoCo XML report for SonarCloud coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,9 @@ tasks.withType(JavaCompile).configureEach {
 // ---- JaCoCo ----
 jacocoTestReport {
     dependsOn test
+    reports {
+        xml.required = true
+    }
 }
 
 jacocoTestCoverageVerification {


### PR DESCRIPTION
## Summary
- Enable JaCoCo XML report generation (`reports.xml.required = true`)
- SonarCloud requires XML reports to import coverage data; without this, coverage shows as 0%

## Test plan
- [ ] `check` workflow passes
- [ ] `sonar` workflow passes and SonarCloud shows coverage data

🤖 Generated with [Claude Code](https://claude.com/claude-code)