### PR TITLE
feat: add production Spring profile

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,4 @@
+logging:
+  level:
+    com.accountabilityatlas: INFO
+    org.springframework.security: WARN


### PR DESCRIPTION
## Summary

- Add `application-prod.yml` with INFO/WARN logging levels for production deployment

Part of the AWS demo deployment effort (AccountabilityAtlas#54).

## Test plan

- [ ] Service starts with `SPRING_PROFILES_ACTIVE=prod`
- [ ] No dev-level debug logging in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)